### PR TITLE
Mass Redacting

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ $user->redactFields(
 
 When a model is redacted, an `AshAllenDesign\RedactableModels\Events\ModelRedacted` event is fired that can be listened on.
 
+Please note, this event is not fired if the model was mass redacted (i.e., the model uses the `AshAllenDesign\RedactableModels\Interfaces\MassRedactable` interface). This is because the models are never actually retrieved from the database when mass redacting, so there isn't a model instance to pass to the event.
+
 ## Testing
 
 To run the package's unit tests, run the following command:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Your model may look something like so:
 
 ```php
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
-use Illuminate\Contracts\Database\Eloquent\Builder
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 class User extends Model implements Redactable
 {
@@ -98,7 +98,7 @@ As an example, if we wanted to redact the `email` and `name` fields from all `Ap
 ```php
 use AshAllenDesign\RedactableModels\Support\Strategies\ReplaceContents;
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
-use Illuminate\Contracts\Database\Eloquent\Builder
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 class User extends Model implements Redactable
 {
@@ -129,7 +129,7 @@ Your model may look something like so:
 
 ```php
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
-use Illuminate\Contracts\Database\Eloquent\Builder
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 class User extends Model implements Redactable
 {

--- a/README.md
+++ b/README.md
@@ -128,21 +128,24 @@ In order to make a model mass redactable, you need to add the `AshAllenDesign\Re
 Your model may look something like so:
 
 ```php
-use AshAllenDesign\RedactableModels\Interfaces\Redactable;
+use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 
-class User extends Model implements Redactable
+class User extends Model implements MassRedactable
 {
     // ...
     
     public function massRedactable(): Builder
     {
-        // ...
+        return static::query()->where('created_at', '<', now()->subDays(30));
     }
 
     public function redactionStrategy(): RedactionStrategy
     {
-        // ...
+        return app(ReplaceContents::class)->replaceWith([
+            'name' => 'REDACTED',
+            'email' => 'redacted@redacted.com',
+        ]);
     }
 }
 ```

--- a/src/Console/Commands/RedactCommand.php
+++ b/src/Console/Commands/RedactCommand.php
@@ -64,12 +64,7 @@ class RedactCommand extends Command
 
         $this->components->info('Mass redacting ['.$count.'] ['.$model.'] models.');
 
-        $chunkSize = 1000;
-        $query->chunk($chunkSize, function ($models) use ($strategy, $model) {
-            $this->components->info('Processing chunk of ['.$models->count().'] ['.$model.'] models.');
-
-            $strategy->massApply($models);
-        });
+        $strategy->massApply($query);
     }
 
     /**

--- a/src/Console/Commands/RedactCommand.php
+++ b/src/Console/Commands/RedactCommand.php
@@ -50,10 +50,6 @@ class RedactCommand extends Command
                 $this->components->info('Processing chunk of ['.$models->count().'] ['.$model.'] models.');
 
                 $strategy->massApply($models);
-
-                $models->each(function ($model) {
-                    event(new ModelRedacted($model));
-                });
             });
         } else {
             /** @var Redactable $instance */

--- a/src/Events/ModelRedacted.php
+++ b/src/Events/ModelRedacted.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace AshAllenDesign\RedactableModels\Events;
 
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
+use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -15,7 +17,7 @@ class ModelRedacted
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Redactable $model)
+    public function __construct(public Model $model)
     {
         //
     }

--- a/src/Events/ModelRedacted.php
+++ b/src/Events/ModelRedacted.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace AshAllenDesign\RedactableModels\Events;
 
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
-use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -17,7 +15,7 @@ class ModelRedacted
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Model $model)
+    public function __construct(public Redactable $model)
     {
         //
     }

--- a/src/Interfaces/MassRedactable.php
+++ b/src/Interfaces/MassRedactable.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\RedactableModels\Interfaces;
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+
+interface MassRedactable
+{
+    public function massRedactable(): Builder;
+
+    public function redactionStrategy(): RedactionStrategy;
+}

--- a/src/Interfaces/RedactionStrategy.php
+++ b/src/Interfaces/RedactionStrategy.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\RedactableModels\Interfaces;
 
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Query\Builder;
 
 interface RedactionStrategy
 {
     public function apply(Redactable&Model $model): void;
 
-    public function massApply(Collection $models): Builder;
+    public function massApply(Builder $query): void;
 }

--- a/src/Interfaces/RedactionStrategy.php
+++ b/src/Interfaces/RedactionStrategy.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\RedactableModels\Interfaces;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
 
 interface RedactionStrategy
 {
     public function apply(Redactable&Model $model): void;
+
+    public function massApply(Collection $models): Builder;
 }

--- a/src/Support/Strategies/FakeStrategy.php
+++ b/src/Support/Strategies/FakeStrategy.php
@@ -4,18 +4,34 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\RedactableModels\Support\Strategies;
 
+use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
 use AshAllenDesign\RedactableModels\Interfaces\RedactionStrategy;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
 use PHPUnit\Framework\Assert;
 
 class FakeStrategy implements RedactionStrategy
 {
     private bool $applied = false;
+    private bool $massApplied = false;
 
     public function apply(Redactable&Model $model): void
     {
         $this->applied = true;
+    }
+
+    public function massApply(Collection $models): Builder
+    {
+        $this->massApplied = true;
+
+        $model = $models->first();
+        if (!$model || !($model instanceof MassRedactable)) {
+            return new Builder(app('db')->connection());
+        }
+
+        return $model->newQuery()->getQuery();
     }
 
     public function assertHasBeenApplied(): void
@@ -23,6 +39,14 @@ class FakeStrategy implements RedactionStrategy
         Assert::assertTrue(
             $this->applied,
             'The redaction strategy has not been applied.',
+        );
+    }
+
+    public function assertHasBeenMassApplied(): void
+    {
+        Assert::assertTrue(
+            $this->massApplied,
+            'The mass redaction strategy has not been applied.',
         );
     }
 }

--- a/src/Support/Strategies/FakeStrategy.php
+++ b/src/Support/Strategies/FakeStrategy.php
@@ -7,10 +7,10 @@ namespace AshAllenDesign\RedactableModels\Support\Strategies;
 use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
 use AshAllenDesign\RedactableModels\Interfaces\RedactionStrategy;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Query\Builder;
 use PHPUnit\Framework\Assert;
+use RuntimeException;
 
 class FakeStrategy implements RedactionStrategy
 {
@@ -22,16 +22,9 @@ class FakeStrategy implements RedactionStrategy
         $this->applied = true;
     }
 
-    public function massApply(Collection $models): Builder
+    public function massApply(Builder $query): void
     {
-        $this->massApplied = true;
-
-        $model = $models->first();
-        if (!$model || !($model instanceof MassRedactable)) {
-            return new Builder(app('db')->connection());
-        }
-
-        return $model->newQuery()->getQuery();
+        throw new RuntimeException('Implement this if we need it for testing.');
     }
 
     public function assertHasBeenApplied(): void

--- a/src/Support/Strategies/HashContents.php
+++ b/src/Support/Strategies/HashContents.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\RedactableModels\Support\Strategies;
 
-use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
 use AshAllenDesign\RedactableModels\Interfaces\RedactionStrategy;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Query\Builder;
 use InvalidArgumentException;
 
 class HashContents implements RedactionStrategy
@@ -28,7 +26,7 @@ class HashContents implements RedactionStrategy
         $model->save();
     }
 
-    public function massApply(Collection $models): Builder
+    public function massApply(Builder $query): void
     {
         throw new InvalidArgumentException('Mass redaction is not supported for the HashContents strategy.');
     }

--- a/src/Support/Strategies/HashContents.php
+++ b/src/Support/Strategies/HashContents.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\RedactableModels\Support\Strategies;
 
+use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
 use AshAllenDesign\RedactableModels\Interfaces\RedactionStrategy;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
+use InvalidArgumentException;
 
 class HashContents implements RedactionStrategy
 {
@@ -22,6 +26,11 @@ class HashContents implements RedactionStrategy
         }
 
         $model->save();
+    }
+
+    public function massApply(Collection $models): Builder
+    {
+        throw new InvalidArgumentException('Mass redaction is not supported for the HashContents strategy.');
     }
 
     /**

--- a/src/Support/Strategies/MaskContents.php
+++ b/src/Support/Strategies/MaskContents.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\RedactableModels\Support\Strategies;
 
-use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
 use AshAllenDesign\RedactableModels\Interfaces\RedactionStrategy;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -36,7 +34,7 @@ class MaskContents implements RedactionStrategy
         $model->save();
     }
 
-    public function massApply(Collection $models): Builder
+    public function massApply(Builder $query): void
     {
         throw new InvalidArgumentException('Mass redaction is not supported for the MaskContents strategy.');
     }

--- a/src/Support/Strategies/MaskContents.php
+++ b/src/Support/Strategies/MaskContents.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\RedactableModels\Support\Strategies;
 
+use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
 use AshAllenDesign\RedactableModels\Interfaces\RedactionStrategy;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 class MaskContents implements RedactionStrategy
 {
@@ -30,6 +34,11 @@ class MaskContents implements RedactionStrategy
         }
 
         $model->save();
+    }
+
+    public function massApply(Collection $models): Builder
+    {
+        throw new InvalidArgumentException('Mass redaction is not supported for the MaskContents strategy.');
     }
 
     public function mask(string $field, string $character, int $index, int $length = null, string $encoding = 'UTF-8'): static

--- a/src/Support/Strategies/ReplaceContents.php
+++ b/src/Support/Strategies/ReplaceContents.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace AshAllenDesign\RedactableModels\Support\Strategies;
 
+use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
 use AshAllenDesign\RedactableModels\Interfaces\Redactable;
 use AshAllenDesign\RedactableModels\Interfaces\RedactionStrategy;
 use Closure;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
 
 class ReplaceContents implements RedactionStrategy
 {
@@ -23,6 +26,26 @@ class ReplaceContents implements RedactionStrategy
             : ($this->replaceWithMappings)($model);
 
         $model->save();
+    }
+
+    public function massApply(Collection $models): Builder
+    {
+        if (!is_array($this->replaceWithMappings)) {
+            throw new \InvalidArgumentException('Mass redaction only supports array mappings, not closures.');
+        }
+
+        $model = $models->first();
+        if (!($model instanceof MassRedactable)) {
+            return new Builder(app('db')->connection());
+        }
+
+        $query = $model->newQuery()
+            ->whereIn('id', $models->pluck('id'))
+            ->getQuery();
+
+        $query->update($this->replaceWithMappings);
+
+        return $query;
     }
 
     /**

--- a/tests/Data/Models/MassRedactableUser.php
+++ b/tests/Data/Models/MassRedactableUser.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\RedactableModels\Tests\Data\Models;
+
+use AshAllenDesign\RedactableModels\Interfaces\MassRedactable;
+use AshAllenDesign\RedactableModels\Interfaces\RedactionStrategy;
+use AshAllenDesign\RedactableModels\Support\Strategies\ReplaceContents;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class MassRedactableUser extends Authenticatable implements MassRedactable
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'email',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+
+    public function massRedactable(): Builder
+    {
+        // Dummy value set as placeholder.
+        return static::query();
+    }
+
+    public function redactionStrategy(): RedactionStrategy
+    {
+        // Dummy value set as placeholder.
+        return (new ReplaceContents())->replaceWith(['name' => 'REDACTED']);
+    }
+}

--- a/tests/Data/Models/MassRedactableUser.php
+++ b/tests/Data/Models/MassRedactableUser.php
@@ -12,6 +12,8 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class MassRedactableUser extends Authenticatable implements MassRedactable
 {
+    protected $table = 'users';
+
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/Feature/Support/Strategies/HashContents/HashContentsTest.php
+++ b/tests/Feature/Support/Strategies/HashContents/HashContentsTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace AshAllenDesign\RedactableModels\Tests\Feature\Support\Strategies\HashContents;
 
 use AshAllenDesign\RedactableModels\Support\Strategies\HashContents;
+use AshAllenDesign\RedactableModels\Tests\Data\Models\MassRedactableUser;
 use AshAllenDesign\RedactableModels\Tests\Data\Models\User;
 use AshAllenDesign\RedactableModels\Tests\TestCase;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 
 class HashContentsTest extends TestCase
@@ -33,5 +35,19 @@ class HashContentsTest extends TestCase
 
         $this->assertSame('7659a2a904e2ac114d3de76d850ebd68', $model->name);
         $this->assertSame('ash@example.com', $model->email);
+    }
+
+    #[Test]
+    public function mass_redaction_throws_exception(): void
+    {
+        $strategy = new HashContents();
+        $strategy->fields(['name']);
+
+        $models = new \Illuminate\Database\Eloquent\Collection([new MassRedactableUser()]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mass redaction is not supported for the HashContents strategy.');
+
+        $strategy->massApply($models);
     }
 }

--- a/tests/Feature/Support/Strategies/HashContents/HashContentsTest.php
+++ b/tests/Feature/Support/Strategies/HashContents/HashContentsTest.php
@@ -8,6 +8,7 @@ use AshAllenDesign\RedactableModels\Support\Strategies\HashContents;
 use AshAllenDesign\RedactableModels\Tests\Data\Models\MassRedactableUser;
 use AshAllenDesign\RedactableModels\Tests\Data\Models\User;
 use AshAllenDesign\RedactableModels\Tests\TestCase;
+use Illuminate\Database\Eloquent\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -43,7 +44,7 @@ class HashContentsTest extends TestCase
         $strategy = new HashContents();
         $strategy->fields(['name']);
 
-        $models = new \Illuminate\Database\Eloquent\Collection([new MassRedactableUser()]);
+        $models = new Collection([new MassRedactableUser()]);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Mass redaction is not supported for the HashContents strategy.');

--- a/tests/Feature/Support/Strategies/HashContents/HashContentsTest.php
+++ b/tests/Feature/Support/Strategies/HashContents/HashContentsTest.php
@@ -44,11 +44,9 @@ class HashContentsTest extends TestCase
         $strategy = new HashContents();
         $strategy->fields(['name']);
 
-        $models = new Collection([new MassRedactableUser()]);
-
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Mass redaction is not supported for the HashContents strategy.');
 
-        $strategy->massApply($models);
+        $strategy->massApply(MassRedactableUser::query());
     }
 }

--- a/tests/Feature/Support/Strategies/MaskContents/MaskContentsTest.php
+++ b/tests/Feature/Support/Strategies/MaskContents/MaskContentsTest.php
@@ -43,11 +43,9 @@ class MaskContentsTest extends TestCase
         $strategy = new MaskContents();
         $strategy->mask('name', '*', 0, 4);
 
-        $models = new Collection([new MassRedactableUser()]);
-
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Mass redaction is not supported for the MaskContents strategy.');
 
-        $strategy->massApply($models);
+        $strategy->massApply(MassRedactableUser::query());
     }
 }

--- a/tests/Feature/Support/Strategies/MaskContents/MaskContentsTest.php
+++ b/tests/Feature/Support/Strategies/MaskContents/MaskContentsTest.php
@@ -8,6 +8,7 @@ use AshAllenDesign\RedactableModels\Support\Strategies\MaskContents;
 use AshAllenDesign\RedactableModels\Tests\Data\Models\MassRedactableUser;
 use AshAllenDesign\RedactableModels\Tests\Data\Models\User;
 use AshAllenDesign\RedactableModels\Tests\TestCase;
+use Illuminate\Database\Eloquent\Collection;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -42,7 +43,7 @@ class MaskContentsTest extends TestCase
         $strategy = new MaskContents();
         $strategy->mask('name', '*', 0, 4);
 
-        $models = new \Illuminate\Database\Eloquent\Collection([new MassRedactableUser()]);
+        $models = new Collection([new MassRedactableUser()]);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Mass redaction is not supported for the MaskContents strategy.');

--- a/tests/Feature/Support/Strategies/MaskContents/MaskContentsTest.php
+++ b/tests/Feature/Support/Strategies/MaskContents/MaskContentsTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace AshAllenDesign\RedactableModels\Tests\Feature\Support\Strategies\MaskContents;
 
 use AshAllenDesign\RedactableModels\Support\Strategies\MaskContents;
+use AshAllenDesign\RedactableModels\Tests\Data\Models\MassRedactableUser;
 use AshAllenDesign\RedactableModels\Tests\Data\Models\User;
 use AshAllenDesign\RedactableModels\Tests\TestCase;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 
 class MaskContentsTest extends TestCase
@@ -32,5 +34,19 @@ class MaskContentsTest extends TestCase
 
         $this->assertSame('****Allen', $model->name);
         $this->assertSame('as---xample.com', $model->email);
+    }
+
+    #[Test]
+    public function mass_redaction_throws_exception(): void
+    {
+        $strategy = new MaskContents();
+        $strategy->mask('name', '*', 0, 4);
+
+        $models = new \Illuminate\Database\Eloquent\Collection([new MassRedactableUser()]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mass redaction is not supported for the MaskContents strategy.');
+
+        $strategy->massApply($models);
     }
 }

--- a/tests/Feature/Support/Strategies/ReplaceContents/ReplaceContentsTest.php
+++ b/tests/Feature/Support/Strategies/ReplaceContents/ReplaceContentsTest.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace AshAllenDesign\RedactableModels\Tests\Feature\Support\Strategies\ReplaceContents;
 
 use AshAllenDesign\RedactableModels\Support\Strategies\ReplaceContents;
+use AshAllenDesign\RedactableModels\Tests\Data\Models\MassRedactableUser;
 use AshAllenDesign\RedactableModels\Tests\Data\Models\User;
 use AshAllenDesign\RedactableModels\Tests\TestCase;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Query\Builder;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 
 class ReplaceContentsTest extends TestCase
@@ -57,5 +61,64 @@ class ReplaceContentsTest extends TestCase
 
         $this->assertSame('name_123', $model->name);
         $this->assertSame('123@example.com', $model->email);
+    }
+
+    #[Test]
+    public function models_can_be_mass_redacted_using_array(): void
+    {
+        $strategy = new ReplaceContents();
+        $strategy->replaceWith(['name' => 'John Doe']);
+
+        $models = [];
+        for ($i = 1; $i <= 3; $i++) {
+            $model = new MassRedactableUser();
+            $model->id = $i;
+            $model->name = 'User '.$i;
+            $model->email = 'user'.$i.'@example.com';
+            $model->password = 'password';
+            $models[] = $model;
+        }
+
+        $strategyMock = $this->getMockBuilder(ReplaceContents::class)
+            ->onlyMethods(['massApply'])
+            ->getMock();
+
+        $strategyMock->replaceWith(['name' => 'John Doe']);
+
+        $strategyMock->method('massApply')
+            ->willReturnCallback(function ($collection) use ($strategyMock) {
+                foreach ($collection as $model) {
+                    $model->name = 'John Doe';
+                }
+
+                return $this->getMockBuilder(Builder::class)
+                    ->disableOriginalConstructor()
+                    ->getMock();
+            });
+
+        $eloquentModels = new Collection($models);
+
+        $strategyMock->massApply($eloquentModels);
+
+        foreach ($models as $model) {
+            $this->assertSame('John Doe', $model->name);
+            $this->assertStringContainsString('@example.com', $model->email);
+        }
+    }
+
+    #[Test]
+    public function mass_redaction_throws_exception_when_using_closure(): void
+    {
+        $strategy = new ReplaceContents();
+        $strategy->replaceWith(function (MassRedactableUser $user): void {
+            $user->name = 'name_'.$user->id;
+        });
+
+        $models = new Collection([new MassRedactableUser()]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mass redaction only supports array mappings, not closures.');
+
+        $strategy->massApply($models);
     }
 }


### PR DESCRIPTION
This PR introduces Mass Redacting to the Package, so instead of going through each model one by one and redacting them, we can pass in a collection of models and update them all in one go. This massively reduces the amount of queries that are ran and also provides a nice time saving bonus too!

Using Mass Redacting is simple, simply change the interface your model implements from `Redactable` to `MassRedactable` and then rename the `redactable()` method to `massRedactable()`. 

I ran some tests and the results are extremely good:

| Number of Models | Execution Time (Normal) | Queries (Normal) | Execution Time (Mass) | Queries (Mass) |
|--------|--------|--------|--------|--------|
| 100,000 | ~80 seconds | 100,102 | ~7 seconds | 202 |
| 500,000 | ~6.5 minutes | 500,502 | ~70 seconds | 1002 |
| 1,000,000 | ~14 minutes | 1,001,002 | ~4 minutes | 2002 |

Benchmarking was done via Christoph Rumpel's excellent [Artisan Benchmark](https://github.com/christophrumpel/artisan-benchmark) package. This was the perfect opportunity to use it! 