### PR TITLE
support customize hash algorithm for HashContents strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Imagine we have a user with ID `123` and a `name` of `John Doe`. Running the abo
 
 #### `HashContents`
 
-The `HashContents` strategy allows you to hash the contents of the field with specific algorithm. "MD5" is the default algorithm.
+The `HashContents` strategy allows you to hash the contents of the field using a given algorithm. By default, the "MD5" hashing algorithm will be used.
 
 This can be useful when you still want to be able to compare the redacted fields, but don't want to expose the original data.
 
@@ -243,12 +243,14 @@ class Invitation extends Model implements Redactable
 
     public function redactionStrategy(): RedactionStrategy
     {
-        return app(HashContents::class))->fields([
+        return app(HashContents::class)->fields([
             'email',
         ])->algo('sha256');
     }
 }
 ```
+
+In the above example, the `email` field would be hashed using the "SHA-256" algorithm. To view all the available hashing algorithms that are supported, you can call the `hash_algos` function in PHP, or check out the PHP documentation: [https://www.php.net/manual/en/function.hash-algos.php](https://www.php.net/manual/en/function.hash-algos.php).
 
 #### `MaskContents`
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Imagine we have a user with ID `123` and a `name` of `John Doe`. Running the abo
 
 #### `HashContents`
 
-The `HashContents` strategy allows you to MD5 hash the contents of the field.
+The `HashContents` strategy allows you to hash the contents of the field with specific algorithm. "MD5" is the default algorithm.
 
 This can be useful when you still want to be able to compare the redacted fields, but don't want to expose the original data.
 
@@ -245,7 +245,7 @@ class Invitation extends Model implements Redactable
     {
         return app(HashContents::class))->fields([
             'email',
-        ]);
+        ])->algo('sha256');
     }
 }
 ```

--- a/src/Support/Strategies/HashContents.php
+++ b/src/Support/Strategies/HashContents.php
@@ -17,10 +17,12 @@ class HashContents implements RedactionStrategy
      */
     private array $fields;
 
+    private string $algo = 'md5';
+
     public function apply(Redactable&Model $model): void
     {
         foreach ($this->fields as $field) {
-            $model->{$field} = hash(algo: 'md5', data: $model->{$field});
+            $model->{$field} = hash(algo: $this->algo, data: $model->{$field});
         }
 
         $model->save();
@@ -29,6 +31,17 @@ class HashContents implements RedactionStrategy
     public function massApply(Builder $query): void
     {
         throw new InvalidArgumentException('Mass redaction is not supported for the HashContents strategy.');
+    }
+
+    public function algo(string $algo): static
+    {
+        if (!in_array($algo, hash_algos())) {
+            throw new InvalidArgumentException("The algorithm `{$algo}` is not supported.");
+        }
+
+        $this->algo = $algo;
+
+        return $this;
     }
 
     /**

--- a/src/Support/Strategies/HashContents.php
+++ b/src/Support/Strategies/HashContents.php
@@ -33,9 +33,12 @@ class HashContents implements RedactionStrategy
         throw new InvalidArgumentException('Mass redaction is not supported for the HashContents strategy.');
     }
 
+    /**
+     * Specify the hashing algorithm to use.
+     */
     public function algo(string $algo): static
     {
-        if (! in_array($algo, hash_algos())) {
+        if (!in_array($algo, hash_algos(), strict: true)) {
             throw new InvalidArgumentException("The algorithm `{$algo}` is not supported.");
         }
 

--- a/src/Support/Strategies/HashContents.php
+++ b/src/Support/Strategies/HashContents.php
@@ -35,7 +35,7 @@ class HashContents implements RedactionStrategy
 
     public function algo(string $algo): static
     {
-        if (!in_array($algo, hash_algos())) {
+        if (! in_array($algo, hash_algos())) {
             throw new InvalidArgumentException("The algorithm `{$algo}` is not supported.");
         }
 

--- a/src/Support/Strategies/HashContents.php
+++ b/src/Support/Strategies/HashContents.php
@@ -38,7 +38,7 @@ class HashContents implements RedactionStrategy
      */
     public function algo(string $algo): static
     {
-        if (!in_array($algo, hash_algos(), strict: true)) {
+        if (! in_array($algo, hash_algos(), strict: true)) {
             throw new InvalidArgumentException("The algorithm `{$algo}` is not supported.");
         }
 

--- a/tests/Feature/Support/Strategies/HashContents/HashContentsTest.php
+++ b/tests/Feature/Support/Strategies/HashContents/HashContentsTest.php
@@ -48,4 +48,41 @@ class HashContentsTest extends TestCase
 
         $strategy->massApply(MassRedactableUser::query());
     }
+
+    #[Test]
+    public function can_customize_hash_algorithm(): void
+    {
+        $strategy = new HashContents();
+        $strategy->fields([
+            'name',
+        ]);
+        $strategy->algo('sha256');
+
+        $model = new User();
+
+        $model->name = 'Ash Allen';
+        $model->email = 'ash@example.com';
+        $model->password = 'password';
+
+        $model->save();
+
+        $strategy->apply($model);
+
+        $model->refresh();
+
+        $this->assertSame('2bc8a057ffc79a7063f26d3b4bc82f8a6b77ac63a26373001f44fa5398548dbb', $model->name);
+        $this->assertSame('ash@example.com', $model->email);
+    }
+
+    #[Test]
+    public function set_invalid_algorithm_throw_exception(): void
+    {
+        $strategy = new HashContents();
+        $strategy->fields(['name']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The algorithm `invalid-algo` is not supported.');
+
+        $strategy->algo('invalid-algo');
+    }
 }


### PR DESCRIPTION
Hey. I made some nice improvements to the HashContents strategy:

1. Now you can choose different hash algorithms - no more being stuck with just md5!
2. Added a friendly warning if you try to use an unsupported algorithm (it'll tell you "I don't know this one!")
3. The whole thing is more robust now when handling sensitive data